### PR TITLE
Added mongoose 3.8.x as a peer dependency. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cls-mongoose",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Continuation-local-storage (CLS) mongoose shim",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "should": "*"
   },
   "peerDependencies": {
-    "mongoose": "^4"
+    "mongoose": ">= 3.8.x"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
It seems to work fine with mongoose 3.8.x.

This is related to issue https://github.com/iliakan/cls-mongoose/issues/2
